### PR TITLE
Change username to email

### DIFF
--- a/lancie-login-form.html
+++ b/lancie-login-form.html
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <lancie-error id="error"></lancie-error>
       <lancie-form id="login" refurl="login" hidden$="[[registering]]" on-response="onLogin">
-        <gold-email-input id="username" label="Email" name="username" error-message="Email should be valid." required autofocus></gold-email-input>
+        <gold-email-input label="Email" name="email" error-message="Email should be valid." required autofocus></gold-email-input>
         <paper-input label="Password" type="password" name="password" required></paper-input>
         <div class="reset">
           <a href="https://areafiftylan.nl/password-reset-request">Forgot password?</a>

--- a/lancie-login-form.html
+++ b/lancie-login-form.html
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </div>
       </lancie-form>
       <lancie-form id="register" refurl="users" hidden$="[[!registering]]" on-response="onRegister">
-        <gold-email-input label="Email" name="username" error-message="Email should be valid." autofocus required></gold-email-input>
+        <gold-email-input label="Email" name="email" error-message="Email should be valid." autofocus required></gold-email-input>
         <lancie-passwords></lancie-passwords>
         <paper-input id="orderId" name="orderId" hidden></paper-input>
       </lancie-form>


### PR DESCRIPTION
The new api version uses "email"  instead of "username". This PR fixes login